### PR TITLE
Favored Class Bonuses

### DIFF
--- a/Derring-Do.csproj
+++ b/Derring-Do.csproj
@@ -87,6 +87,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Components\InspiredStrike.cs" />
+    <Compile Include="Swashbuckler\FavoredClass.cs" />
     <Compile Include="Swashbuckler\InspiredBlade.cs" />
     <Compile Include="Swashbuckler\Swashbuckler.cs" />
     <Compile Include="Components\AbilityDeliver.cs" />

--- a/Swashbuckler/FavoredClass.cs
+++ b/Swashbuckler/FavoredClass.cs
@@ -1,0 +1,54 @@
+﻿using CallOfTheWild;
+using Kingmaker.Blueprints;
+using Kingmaker.Blueprints.Classes;
+using Kingmaker.UnitLogic.FactLogic;
+
+namespace Derring_Do
+{
+    class FavoredClass
+    {
+        static LibraryScriptableObject library = Main.library;
+
+        static BlueprintFeature bonus_panache;
+
+        static BlueprintFeature bonus_charmed_life;
+
+        static public void create()
+        {
+            Main.DebugLog("Creating favored class bonuses");
+            createBonusPanache();
+            createBonusCharmedLife();
+
+            library.AddAsset(bonus_panache, bonus_panache.AssetGuid);
+            library.AddAsset(bonus_charmed_life, bonus_charmed_life.AssetGuid);
+        }
+
+        static void createBonusPanache()
+        {
+            bonus_panache = Helpers.CreateFeature("BonusPanacheSwashbucklerFavoredClassFeature",
+                                                  "Bonus Panache Pool",
+                                                  "Increase the total number of points in the swashbuckler’s panache pool by 1/4.",
+                                                  "89b0082da456424380b5c541f63eee41",
+                                                  Swashbuckler.panache.Icon,
+                                                  FeatureGroup.None,
+                                                  Helpers.Create<IncreaseResourceAmount>(i => { i.Resource = Swashbuckler.panache_resource; i.Value = 1; })
+                                                  );
+            bonus_panache.Ranks = 5;
+            bonus_panache.ReapplyOnLevelUp = true;
+        }
+
+        static void createBonusCharmedLife()
+        {
+            bonus_charmed_life = Helpers.CreateFeature("BonusCharmedLifeSwashbucklerFavoredClassFeature",
+                                                       "Bonus Charmed Life Uses",
+                                                       "Increase the number of times per day the swashbuckler can use charmed life by 1/4.",
+                                                       "57b8c544535f40918881cf4000021a40",
+                                                       Swashbuckler.charmed_life.Icon,
+                                                       FeatureGroup.None,
+                                                       Helpers.Create<IncreaseResourceAmount>(i => { i.Resource = Swashbuckler.charmed_life_resource; i.Value = 1; })
+                                                       );
+            bonus_charmed_life.Ranks = 5;
+            bonus_charmed_life.ReapplyOnLevelUp = true;
+        }
+    }
+}

--- a/Swashbuckler/FavoredClass.cs
+++ b/Swashbuckler/FavoredClass.cs
@@ -23,9 +23,6 @@ namespace Derring_Do
             Main.DebugLog("Creating favored class bonuses");
             createBonusPanache();
             createBonusCharmedLife();
-
-            library.AddAsset(bonus_panache, bonus_panache.AssetGuid);
-            library.AddAsset(bonus_charmed_life, bonus_charmed_life.AssetGuid);
         }
 
         static void createBonusPanache()

--- a/Swashbuckler/FavoredClass.cs
+++ b/Swashbuckler/FavoredClass.cs
@@ -1,7 +1,12 @@
 ﻿using CallOfTheWild;
+using CallOfTheWild.ResourceMechanics;
 using Kingmaker.Blueprints;
 using Kingmaker.Blueprints.Classes;
+using Kingmaker.Blueprints.Facts;
+using Kingmaker.Designers.Mechanics.Facts;
+using Kingmaker.Enums;
 using Kingmaker.UnitLogic.FactLogic;
+using Kingmaker.UnitLogic.Mechanics.Components;
 
 namespace Derring_Do
 {
@@ -31,8 +36,10 @@ namespace Derring_Do
                                                   "89b0082da456424380b5c541f63eee41",
                                                   Swashbuckler.panache.Icon,
                                                   FeatureGroup.None,
-                                                  Helpers.Create<IncreaseResourceAmount>(i => { i.Resource = Swashbuckler.panache_resource; i.Value = 1; })
+                                                  Helpers.Create<ContextIncreaseResourceAmount>(i => { i.Resource = Swashbuckler.panache_resource; i.Value = Helpers.CreateContextValue(AbilityRankType.Default); })
                                                   );
+            bonus_panache.AddComponent(Helpers.CreateContextRankConfig(baseValueType: ContextRankBaseValueType.FeatureRank, feature: bonus_panache));
+            bonus_panache.AddComponent(Helpers.Create<RecalculateOnFactsChange>(r => r.CheckedFacts = new BlueprintUnitFact[] { bonus_panache }));
             bonus_panache.Ranks = 5;
             bonus_panache.ReapplyOnLevelUp = true;
         }
@@ -45,8 +52,10 @@ namespace Derring_Do
                                                        "57b8c544535f40918881cf4000021a40",
                                                        Swashbuckler.charmed_life.Icon,
                                                        FeatureGroup.None,
-                                                       Helpers.Create<IncreaseResourceAmount>(i => { i.Resource = Swashbuckler.charmed_life_resource; i.Value = 1; })
+                                                       Helpers.Create<ContextIncreaseResourceAmount>(i => { i.Resource = Swashbuckler.charmed_life_resource; i.Value = Helpers.CreateContextValue(AbilityRankType.Default); })
                                                        );
+            bonus_charmed_life.AddComponent(Helpers.CreateContextRankConfig(baseValueType: ContextRankBaseValueType.FeatureRank, feature: bonus_charmed_life));
+            bonus_charmed_life.AddComponent(Helpers.Create<RecalculateOnFactsChange>(r => r.CheckedFacts = new BlueprintUnitFact[] { bonus_charmed_life }));
             bonus_charmed_life.Ranks = 5;
             bonus_charmed_life.ReapplyOnLevelUp = true;
         }

--- a/Swashbuckler/Swashbuckler.cs
+++ b/Swashbuckler/Swashbuckler.cs
@@ -62,6 +62,7 @@ namespace Derring_Do
         static public BlueprintFeature swashbuckler_finesse;
 
         static public BlueprintFeature charmed_life;
+        static public BlueprintAbilityResource charmed_life_resource;
 
         static public BlueprintFeature nimble_unlock;
 
@@ -167,6 +168,8 @@ namespace Derring_Do
             swashbuckler_class.Archetypes = new BlueprintArchetype[] { InspiredBlade.inspired_blade };
 
             SwashbucklerFeats.createFeats();
+
+            FavoredClass.create();
         }
 
         static BlueprintCharacterClass[] getSwashbucklerArray()
@@ -332,7 +335,7 @@ namespace Derring_Do
         {
             var bravery = library.Get<BlueprintFeature>("f6388946f9f472f4585591b80e9f2452");
 
-            var charmed_life_resource = CreateAbilityResource("SwashbucklerCharmedLifeResource", "", "", "cdaca00ebd144d8b870390fb6a09640f", null);
+            charmed_life_resource = CreateAbilityResource("SwashbucklerCharmedLifeResource", "", "", "cdaca00ebd144d8b870390fb6a09640f", null);
             charmed_life_resource.SetIncreasedByLevelStartPlusDivStep(3, 2, 0, 4, 1, 0, 0.0f, getSwashbucklerArray());
 
             var consume_resource = Common.createContextActionSpendResource(charmed_life_resource, 1);


### PR DESCRIPTION
Favored class bonuses:
- Increase panache pool for humans, elves and human-like races
- Increasd charmed life usage for Gnomes, Half Elves and Halflings