### PR TITLE
Rostland Bravo

### DIFF
--- a/Components/CasterCheck.cs
+++ b/Components/CasterCheck.cs
@@ -1,6 +1,7 @@
 ﻿using Kingmaker.Blueprints;
 using Kingmaker.EntitySystem.Entities;
 using Kingmaker.Enums;
+using Kingmaker.UnitLogic;
 using Kingmaker.UnitLogic.Abilities.Blueprints;
 using Kingmaker.UnitLogic.Abilities.Components.Base;
 using static Derring_Do.Extensions;
@@ -22,18 +23,20 @@ namespace Derring_Do
         }
     }
 
-    [ComponentName("Check Caster is Wielding a Dueling Sword")]
+    [ComponentName("Check Caster is Wielding Only a Dueling Sword")]
     [AllowedOn(typeof(BlueprintAbility))]
     [AllowedOn(typeof(BlueprintComponent))]
     public class AbilityCasterDuelingSwordCheck : BlueprintComponent, IAbilityCasterChecker
     {
         public bool CorrectCaster(UnitEntityData caster)
         {
-            return (caster.Body.PrimaryHand.Weapon.Blueprint.Category == WeaponCategory.DuelingSword);
+            bool flag = caster.Body.PrimaryHand.Weapon.Blueprint.Category == WeaponCategory.DuelingSword;
+            bool flag2 = caster.Body.SecondaryHand.HasWeapon && caster.Body.SecondaryHand.MaybeWeapon != caster.Body.EmptyHandWeapon;
+            return (flag && !flag2 && !caster.Body.SecondaryHand.HasShield);
         }
         public string GetReason()
         {
-            return "Invalid weapon";
+            return "Must be wielding only a Dueling Sword";
         }
     }
 

--- a/Components/CasterCheck.cs
+++ b/Components/CasterCheck.cs
@@ -1,5 +1,6 @@
 ﻿using Kingmaker.Blueprints;
 using Kingmaker.EntitySystem.Entities;
+using Kingmaker.Enums;
 using Kingmaker.UnitLogic.Abilities.Blueprints;
 using Kingmaker.UnitLogic.Abilities.Components.Base;
 using static Derring_Do.Extensions;
@@ -14,6 +15,21 @@ namespace Derring_Do
         public bool CorrectCaster(UnitEntityData caster)
         {
             return (isSwashbucklerWeapon(caster.Body.PrimaryHand.Weapon.Blueprint, caster.Descriptor) || isSwashbucklerWeapon(caster.Body.SecondaryHand.Weapon.Blueprint, caster.Descriptor));
+        }
+        public string GetReason()
+        {
+            return "Invalid weapon";
+        }
+    }
+
+    [ComponentName("Check Caster is Wielding a Dueling Sword")]
+    [AllowedOn(typeof(BlueprintAbility))]
+    [AllowedOn(typeof(BlueprintComponent))]
+    public class AbilityCasterDuelingSwordCheck : BlueprintComponent, IAbilityCasterChecker
+    {
+        public bool CorrectCaster(UnitEntityData caster)
+        {
+            return (caster.Body.PrimaryHand.Weapon.Blueprint.Category == WeaponCategory.DuelingSword);
         }
         public string GetReason()
         {

--- a/Components/Panache.cs
+++ b/Components/Panache.cs
@@ -97,6 +97,14 @@ namespace Derring_Do
             {
                 return false;
             }
+            if (this.OnlyOnFullAttack && !evt.IsFullAttack)
+            {
+                return false;
+            }
+            if (this.OnlyOnFirstAttack && !evt.IsFirstAttack)
+            {
+                return false;
+            }
             bool flag = evt.Weapon.Blueprint.Category.HasSubCategory(WeaponSubCategory.Light) || evt.Weapon.Blueprint.Category.HasSubCategory(WeaponSubCategory.OneHandedPiercing) || (evt.Initiator.Descriptor.State.Features.DuelingMastery && evt.Weapon.Blueprint.Category == WeaponCategory.DuelingSword) || evt.Initiator.Descriptor.Ensure<DamageGracePart>().HasEntry(evt.Weapon.Blueprint.Category);
             return !this.DuelistWeapon || flag;
         }
@@ -121,6 +129,10 @@ namespace Derring_Do
             }
             return true;
         }
+
+        public bool OnlyOnFirstAttack;
+
+        public bool OnlyOnFullAttack;
 
         public BlueprintBuff deadly_stab_buff;
 

--- a/Components/TerrorOfTheGreatWyrm.cs
+++ b/Components/TerrorOfTheGreatWyrm.cs
@@ -1,0 +1,56 @@
+﻿using Kingmaker.ElementsSystem;
+using Kingmaker.EntitySystem.Entities;
+using Kingmaker.EntitySystem.Stats;
+using Kingmaker.RuleSystem.Rules;
+using Kingmaker.UnitLogic;
+using Kingmaker.UnitLogic.Buffs.Blueprints;
+using Kingmaker.UnitLogic.Mechanics;
+using Kingmaker.UnitLogic.Mechanics.Actions;
+using Kingmaker.Utility;
+using System;
+
+namespace Derring_Do
+{
+    public class TerrorOfTheGreatWyrmDemoralize : ContextAction
+    {
+        public BlueprintBuff Buff;
+        public BlueprintBuff GreaterBuff;
+
+        public override string GetCaption()
+        {
+            return "Demoralize target with action when over duration";
+        }
+
+        public override void RunAction()
+        {
+            MechanicsContext context = ElementsContext.GetData<MechanicsContext.Data>()?.Context;
+            UnitEntityData maybeCaster = context?.MaybeCaster;
+            if (maybeCaster == null || !this.Target.IsUnit)
+            {
+                UberDebug.LogError((UnityEngine.Object)this, (object)"Unable to apply buff: no context found", (object[])Array.Empty<object>());
+            }
+            else
+            {
+                int dc = 10 + this.Target.Unit.Descriptor.Progression.CharacterLevel + this.Target.Unit.Stats.Wisdom.Bonus;
+                try
+                {
+                    RuleSkillCheck ruleSkillCheck = context.TriggerRule<RuleSkillCheck>(new RuleSkillCheck(maybeCaster, StatType.CheckIntimidate, dc));
+                    if (!ruleSkillCheck.IsPassed)
+                        return;
+                    int num1 = 1 + (ruleSkillCheck.RollResult - dc) / 5 + (!(bool)maybeCaster.Descriptor.State.Features.FrighteningThug ? 0 : 1);
+                    if ((bool)maybeCaster.Descriptor.State.Features.FrighteningThug && num1 >= 4)
+                        this.Target.Unit.Descriptor.AddBuff(this.GreaterBuff, context, new TimeSpan?(1.Rounds().Seconds));
+                    if (num1 >= 3)
+                    {
+                        this.Target.Unit.Descriptor.AddBuff(this.GreaterBuff, context, new TimeSpan?(1.Rounds().Seconds));
+                        num1++; //Mimicks the fact that the lesser buff is applied after this greater buff wears off.
+                    }
+                    Kingmaker.UnitLogic.Buffs.Buff buff1 = this.Target.Unit.Descriptor.AddBuff(this.Buff, context, new TimeSpan?(num1.Rounds().Seconds));
+                }
+                finally
+                {
+                }
+            }
+        }
+    }
+}

--- a/Derring-Do.csproj
+++ b/Derring-Do.csproj
@@ -46,6 +46,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Kingmaker\Kingmaker_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="ProperFlanking20">
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Kingmaker\Mods\ProperFlanking2\ProperFlanking20.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -87,6 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Components\InspiredStrike.cs" />
+    <Compile Include="Components\TerrorOfTheGreatWyrm.cs" />
     <Compile Include="Swashbuckler\FavoredClass.cs" />
     <Compile Include="Swashbuckler\InspiredBlade.cs" />
     <Compile Include="Swashbuckler\RostlandBravo.cs" />

--- a/Derring-Do.csproj
+++ b/Derring-Do.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Components\InspiredStrike.cs" />
     <Compile Include="Swashbuckler\FavoredClass.cs" />
     <Compile Include="Swashbuckler\InspiredBlade.cs" />
+    <Compile Include="Swashbuckler\RostlandBravo.cs" />
     <Compile Include="Swashbuckler\Swashbuckler.cs" />
     <Compile Include="Components\AbilityDeliver.cs" />
     <Compile Include="Components\BleedingWound.cs" />

--- a/Main.cs
+++ b/Main.cs
@@ -61,7 +61,7 @@ namespace Derring_Do
 
         [Harmony12.HarmonyPatch(typeof(LibraryScriptableObject), "LoadDictionary")]
         [Harmony12.HarmonyPatch(typeof(LibraryScriptableObject), "LoadDictionary", new Type[0])]
-        [Harmony12.HarmonyAfter("ProperFlanking2")]
+        [Harmony12.HarmonyAfter("CallOfTheWild", "ProperFlanking2")]
         static class LibraryScriptableObject_LoadDictionary_Patch
         {
             static void Postfix(LibraryScriptableObject __instance)

--- a/Swashbuckler/RostlandBravo.cs
+++ b/Swashbuckler/RostlandBravo.cs
@@ -1,0 +1,132 @@
+﻿using CallOfTheWild;
+using Kingmaker.Blueprints;
+using Kingmaker.Blueprints.Classes;
+using Kingmaker.Blueprints.Items;
+using Kingmaker.Blueprints.Items.Weapons;
+using Kingmaker.Designers.Mechanics.Facts;
+using Kingmaker.EntitySystem.Stats;
+using Kingmaker.Enums;
+using Kingmaker.UnitLogic.Abilities.Blueprints;
+using Kingmaker.UnitLogic.Abilities.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static CallOfTheWild.Helpers;
+using static Kingmaker.UnitLogic.Commands.Base.UnitCommand;
+
+namespace Derring_Do
+{
+    class RostlandBravo
+    {
+        static LibraryScriptableObject library = Main.library;
+
+        static public BlueprintArchetype rostland_bravo;
+
+        static public BlueprintFeature rostland_bravo_proficiencies;
+
+        static public BlueprintFeature aldori_swashbuckler;
+
+        static public BlueprintFeature inevitable_victory_deed;
+
+        static public BlueprintFeature sweeping_wind_feint;
+
+        static public BlueprintFeature dragons_rage_deed;
+
+        static public BlueprintFeature terror_of_the_great_wyrm_deed;
+
+        static public void create()
+        {
+            Main.DebugLog("Creating Rostland Bravo archetype");
+            rostland_bravo = Helpers.Create<BlueprintArchetype>(a =>
+            {
+                a.name = "RostlandBravoSwashbucklerArchetype";
+                a.LocalizedName = Helpers.CreateString($"{a.name}.Name", "Rostland Bravo");
+                a.LocalizedDescription = Helpers.CreateString($"{a.name}.Description", "The Free City of Restov is host to numerous dueling schools, from the renowned Aldori Academy to tiny training grounds in blademasters’ homes. Students of these schools are notoriously competitive, and street-corner duels at dawn and dusk are a constant of Restov life. In most cases, while these “lesser schools” do not teach official Aldori techniques, their methods mesh well with that signature style. Unsurprisingly, many students eventually train in the Aldori style, whether because they aspire to join the swordlords’ ranks or simply for the challenge of mastering the legendary weapon. While some favor more technical approaches, others study flashier maneuvers, wielding the curved blade with artful flair. Disdainfully called “bravos” by classically trained rivals, students of this approach have claimed the label with pride. The Rostland bravos’ most advanced techniques bear dragon-themed names as a snub to traditionalist Aldori swordlords, who have never forgotten their crushing defeat by Choral the Conqueror’s dragons at the Valley of Fire.");
+            });
+            SetField(rostland_bravo, "m_ParentClass", Swashbuckler.swashbuckler_class);
+            library.AddAsset(rostland_bravo, "8a2a3b210e5a4fc1b1429365515695fd");
+
+            rostland_bravo.ReplaceStartingEquipment = true;
+            rostland_bravo.StartingItems = new BlueprintItem[]
+            {
+                library.Get<BlueprintItem>("afbe88d27a0eb544583e00fa78ffb2c7"), //StuddedStandard
+                library.Get<BlueprintItem>("4697667a33a6774489e5265a955675a5"), //StandardDuelingSword
+                library.Get<BlueprintItem>("bc93a78d71bef084fa155e529660ed0d"), //PotionOfShieldOfFaith
+                library.Get<BlueprintItem>("d52566ae8cbe8dc4dae977ef51c27d91"), //PotionOfCureLightWounds
+            };
+
+            rostland_bravo.ReplaceClassSkills = true;
+            rostland_bravo.ClassSkills = new StatType[] { StatType.SkillMobility, StatType.SkillKnowledgeWorld, StatType.SkillPerception, StatType.SkillPersuasion };
+
+            //Create Features
+            createRostlandBravoProficiencies();
+            createAldoriSwashbuckler();
+            createInevitableVictory();
+
+            rostland_bravo.RemoveFeatures = new LevelEntry[] { Helpers.LevelEntry(1, Swashbuckler.swashbuckler_proficiencies),
+                                                               Helpers.LevelEntry(3, Swashbuckler.menacing_swordplay_deed),
+                                                               Helpers.LevelEntry(7, Swashbuckler.superior_feint_deed),
+                                                               Helpers.LevelEntry(11, Swashbuckler.bleeding_wound_deed),
+                                                               Helpers.LevelEntry(15, Swashbuckler.swashbucklers_edge_deed),
+                                                             };
+
+            rostland_bravo.AddFeatures = new LevelEntry[] { Helpers.LevelEntry(1, rostland_bravo_proficiencies),
+                                                            Helpers.LevelEntry(3, inevitable_victory_deed),
+                                                            Helpers.LevelEntry(7, sweeping_wind_feint),
+                                                            Helpers.LevelEntry(11, dragons_rage_deed),
+                                                            Helpers.LevelEntry(15, terror_of_the_great_wyrm_deed),
+                                                          };
+            Swashbuckler.swashbuckler_progression.UIDeterminatorsGroup = Swashbuckler.swashbuckler_progression.UIDeterminatorsGroup.AddToArray(rostland_bravo_proficiencies, aldori_swashbuckler);
+        }
+
+        static void createRostlandBravoProficiencies()
+        {
+            rostland_bravo_proficiencies = library.CopyAndAdd<BlueprintFeature>("8f8c2640ffad89349883fc2e5ff2091e", //magus proficiencies
+                                                                                "RostlandBravoSwashbucklerProficiencies",
+                                                                                "12f3c40bac26460f97ec10e3e5e28035");
+
+            rostland_bravo_proficiencies.RemoveComponents<ArcaneArmorProficiency>();
+            rostland_bravo_proficiencies.AddComponent(Common.createAddWeaponProficiencies(WeaponCategory.DuelingSword));
+            rostland_bravo_proficiencies.SetName("Rostland Bravo Proficiencies");
+            rostland_bravo_proficiencies.SetDescription("The Rostland bravo is not proficient with bucklers.");
+        }
+
+        static void createAldoriSwashbuckler()
+        {
+            var dueling_sword = library.Get<BlueprintWeaponType>("a6f7e3dc443ff114ba68b4648fd33e9f");
+
+            aldori_swashbuckler = CreateFeature("AldoriSwashbucklerSwashbucklerFeature",
+                                                "Aldori Swashbuckler",
+                                                "A Rostland bravo focuses on the Aldori dueling sword, scorning the bucklers used by duelists of other styles. In addition, the relative safety and creature comforts allowed by life in the sprawling city of Restov reduces her need for athleticism. A Rostland bravo gains Exotic Weapon Proficiency (Aldori dueling sword) as a bonus feat. The Rostland bravo is not proficient with bucklers, and does not gain Athletics as a class skill.",
+                                                "77a77a09003d4b398ef3f6dc852fd03e",
+                                                dueling_sword.Icon,
+                                                FeatureGroup.None
+                                                );
+        }
+
+        static void createInevitableVictory()
+        {
+            var dazzling_display_feature = library.Get<BlueprintFeature>("bcbd674ec70ff6f4894bb5f07b6f4095");
+            var dazzling_diplay_ability = library.Get<BlueprintAbility>("5f3126d4120b2b244a95cb2ec23d69fb");
+            var inevitable_victory_ability = CreateAbility("InevitableVictorySwashbucklerAbility",
+                                                           "Inevitable Victory",
+                                                           "The Rostland bravo’s technique is all about flair; a display of her skill is enough to make any Restov brawler reconsider picking a fight. At 3rd level, the Rostland bravo gains Dazzling Display as a bonus feat. She can activate its effect only while wielding an Aldori dueling sword, and she must spend 1 panache point to do so.",
+                                                           "de27de8ad462406daf934325b02a1bcd",
+                                                           null, //TODO icon
+                                                           AbilityType.Extraordinary,
+                                                           CommandType.Swift,
+                                                           dazzling_diplay_ability.Range,
+                                                           dazzling_diplay_ability.LocalizedDuration,
+                                                           dazzling_diplay_ability.LocalizedSavingThrow
+                                                           );
+            inevitable_victory_ability.ComponentsArray = dazzling_diplay_ability.ComponentsArray.AddToArray(Create<AbilityCasterDuelingSwordCheck>(), Create<AbilityResourceLogic>(a => { a.Amount = 1; a.IsSpendResource = true; a.RequiredResource = Swashbuckler.panache_resource; }));
+        }
+
+        static void createSweepingWindFeint()
+        {
+
+        }
+    }
+}

--- a/Swashbuckler/RostlandBravo.cs
+++ b/Swashbuckler/RostlandBravo.cs
@@ -1,4 +1,5 @@
 ﻿using CallOfTheWild;
+using CallOfTheWild.NewMechanics;
 using Kingmaker.Blueprints;
 using Kingmaker.Blueprints.Classes;
 using Kingmaker.Blueprints.Items;
@@ -8,11 +9,12 @@ using Kingmaker.EntitySystem.Stats;
 using Kingmaker.Enums;
 using Kingmaker.UnitLogic.Abilities.Blueprints;
 using Kingmaker.UnitLogic.Abilities.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Kingmaker.UnitLogic.Abilities.Components.Base;
+using Kingmaker.UnitLogic.ActivatableAbilities;
+using Kingmaker.UnitLogic.Buffs.Blueprints;
+using Kingmaker.UnitLogic.Mechanics.Actions;
+using Kingmaker.UnitLogic.Mechanics.Components;
+using Kingmaker.UnitLogic.Mechanics.Conditions;
 using static CallOfTheWild.Helpers;
 using static Kingmaker.UnitLogic.Commands.Base.UnitCommand;
 
@@ -35,6 +37,7 @@ namespace Derring_Do
         static public BlueprintFeature dragons_rage_deed;
 
         static public BlueprintFeature terror_of_the_great_wyrm_deed;
+        static public BlueprintBuff terror_of_the_great_wyrm_buff;
 
         static public void create()
         {
@@ -64,6 +67,9 @@ namespace Derring_Do
             createRostlandBravoProficiencies();
             createAldoriSwashbuckler();
             createInevitableVictory();
+            createSweepingWindFeint();
+            createDragonsRage();
+            createTerrorOfTheGreatWyrm();
 
             rostland_bravo.RemoveFeatures = new LevelEntry[] { Helpers.LevelEntry(1, Swashbuckler.swashbuckler_proficiencies),
                                                                Helpers.LevelEntry(3, Swashbuckler.menacing_swordplay_deed),
@@ -72,7 +78,7 @@ namespace Derring_Do
                                                                Helpers.LevelEntry(15, Swashbuckler.swashbucklers_edge_deed),
                                                              };
 
-            rostland_bravo.AddFeatures = new LevelEntry[] { Helpers.LevelEntry(1, rostland_bravo_proficiencies),
+            rostland_bravo.AddFeatures = new LevelEntry[] { Helpers.LevelEntry(1, rostland_bravo_proficiencies, aldori_swashbuckler),
                                                             Helpers.LevelEntry(3, inevitable_victory_deed),
                                                             Helpers.LevelEntry(7, sweeping_wind_feint),
                                                             Helpers.LevelEntry(11, dragons_rage_deed),
@@ -108,25 +114,152 @@ namespace Derring_Do
 
         static void createInevitableVictory()
         {
+            var stunning_barrier = library.Get<BlueprintAbility>("a5ec7892fb1c2f74598b3a82f3fd679f");
             var dazzling_display_feature = library.Get<BlueprintFeature>("bcbd674ec70ff6f4894bb5f07b6f4095");
-            var dazzling_diplay_ability = library.Get<BlueprintAbility>("5f3126d4120b2b244a95cb2ec23d69fb");
-            var inevitable_victory_ability = CreateAbility("InevitableVictorySwashbucklerAbility",
-                                                           "Inevitable Victory",
-                                                           "The Rostland bravo’s technique is all about flair; a display of her skill is enough to make any Restov brawler reconsider picking a fight. At 3rd level, the Rostland bravo gains Dazzling Display as a bonus feat. She can activate its effect only while wielding an Aldori dueling sword, and she must spend 1 panache point to do so.",
-                                                           "de27de8ad462406daf934325b02a1bcd",
-                                                           null, //TODO icon
-                                                           AbilityType.Extraordinary,
-                                                           CommandType.Swift,
-                                                           dazzling_diplay_ability.Range,
-                                                           dazzling_diplay_ability.LocalizedDuration,
-                                                           dazzling_diplay_ability.LocalizedSavingThrow
-                                                           );
-            inevitable_victory_ability.ComponentsArray = dazzling_diplay_ability.ComponentsArray.AddToArray(Create<AbilityCasterDuelingSwordCheck>(), Create<AbilityResourceLogic>(a => { a.Amount = 1; a.IsSpendResource = true; a.RequiredResource = Swashbuckler.panache_resource; }));
+            var inevitable_victory_ability = library.CopyAndAdd<BlueprintAbility>("5f3126d4120b2b244a95cb2ec23d69fb", "InevitableVictorySwashbucklerAbility", "12e5c8239c7d4ac2a5bd7813996d358e"); //Dazzling display
+
+
+            inevitable_victory_ability.SetNameDescriptionIcon("Inevitable Victory",
+                                                              "The Rostland bravo’s technique is all about flair; a display of her skill is enough to make any Restov brawler reconsider picking a fight. At 3rd level, the Rostland bravo gains Dazzling Display as a bonus feat. She can activate its effect only while wielding, an Aldori dueling sword, and she must spend 1 panache point to do so.",
+                                                              stunning_barrier.Icon
+                                                              );
+            inevitable_victory_ability.AddComponent(Create<AbilityCasterDuelingSwordCheck>());
+            inevitable_victory_ability.AddComponent(Create<AbilityResourceLogic>(a => { a.Amount = 1; a.RequiredResource = Swashbuckler.panache_resource; a.IsSpendResource = true; }));
+
+            inevitable_victory_deed = CreateFeature("InevitableVictorySwashbucklerFeature",
+                                                    inevitable_victory_ability.Name,
+                                                    inevitable_victory_ability.Description,
+                                                    "cc548dc23ebe4423af7b002506d2983e",
+                                                    inevitable_victory_ability.Icon,
+                                                    FeatureGroup.None,
+                                                    Helpers.CreateAddFact(inevitable_victory_ability)
+                                                    );
+
+            dazzling_display_feature.AddComponent(Create<FeatureReplacement>(f => f.replacement_feature = inevitable_victory_deed));
         }
 
         static void createSweepingWindFeint()
         {
+            var see_invis = library.Get<BlueprintAbility>("30e5dc243f937fc4b95d2f8f4e1b7ff3");
+            var sweeping_wind_feint_ability = library.CopyAndAdd<BlueprintAbility>("2d5f22af097646e9a9113bcf42976d7f", "SweepingWindFeintSwashbucklerAbility", "297034d66f284a668b4f05b95761f785"); //from properflanking2
 
+            sweeping_wind_feint_ability.SetNameDescriptionIcon("Sweeping Wind Feint",
+                                                               "At 7th level, the Rostland bravo masters an exotic feinting style, tossing her blade to the other hand and performing a sweeping attack or upward slash before the opponent reacts. Once per round, she can spend 1 point of panache to attempt a feint as a swift action.",
+                                                               see_invis.Icon
+                                                               );
+            SetField(sweeping_wind_feint_ability, "ActionType", CommandType.Swift);
+            SetField(sweeping_wind_feint_ability, "Type", AbilityType.Extraordinary);
+            sweeping_wind_feint_ability.AddComponent(Create<AbilityCasterDuelingSwordCheck>());
+            sweeping_wind_feint_ability.AddComponent(Create<AbilityResourceLogic>(a => { a.Amount = 1; a.IsSpendResource = true; a.RequiredResource = Swashbuckler.panache_resource; }));
+
+            sweeping_wind_feint = CreateFeature("SweepingWindFeintSwashbucklerFeature",
+                                                sweeping_wind_feint_ability.Name,
+                                                sweeping_wind_feint_ability.Description,
+                                                "8c7eb71834ed492384e86f8086808c9e",
+                                                sweeping_wind_feint_ability.Icon,
+                                                FeatureGroup.None,
+                                                Helpers.CreateAddFact(sweeping_wind_feint_ability)
+                                                );
+        }
+
+        static void createDragonsRage()
+        {
+            var dragons_breath = library.Get<BlueprintAbility>("5e826bcdfde7f82468776b55315b2403");
+
+            var buff = CreateBuff("DragonsRageSwashbucklerBuff",
+                                  "Dragon’s Rage",
+                                  "At 11th level, the Rostland bravo can cast aside restraint in favor of a blindingly fast assault of unpredictable strikes inspired in part by the overwhelming brutality of a dragon in combat. Once per round as part of a full attack, the bravo can spend 1 panache point to make an additional attack with her Aldori dueling sword at her highest attack bonus. If she reduces a creature to 0 or fewer hit points with this additional attack, she regains 2 panache points rather than the normal 1 point she would gain from striking a killing blow.",
+                                  "a7cee45d8dee4416be365b000681472d",
+                                  dragons_breath.Icon,
+                                  null,
+                                  Create<CallOfTheWild.NewMechanics.BuffExtraAttackCategorySpecific>(b => b.categories = new WeaponCategory[] { WeaponCategory.DuelingSword }),
+                                  Create<RestorePanacheAttackRollTrigger>(a => { a.ReduceHPToZero = true; a.Action = CreateActionList(Swashbuckler.restore_panache); a.CheckWeaponCategory = true; a.Category = WeaponCategory.DuelingSword; a.OnlyOnFullAttack = true; a.OnlyOnFirstAttack = true; })
+                                  );
+
+            var apply_buff = Common.createContextActionApplyBuff(buff, Helpers.CreateContextDuration(1), dispellable: false);
+
+            var ability = CreateAbility("DragonsRageSwashbucklerAbility",
+                                        buff.Name,
+                                        buff.Description,
+                                        "ecf13592ed694f41a7a4b1bfc8f06505",
+                                        buff.Icon,
+                                        AbilityType.Extraordinary,
+                                        CommandType.Free,
+                                        AbilityRange.Personal,
+                                        oneRoundDuration,
+                                        "",
+                                        CreateRunActions(apply_buff),
+                                        Create<AbilityResourceLogic>(a => { a.Amount = 1; a.IsSpendResource = true; a.RequiredResource = Swashbuckler.panache_resource; }),
+                                        Create<AbilityCasterDuelingSwordCheck>()
+                                        );
+            ability.setMiscAbilityParametersSelfOnly();
+
+            dragons_rage_deed = CreateFeature("DragonsRageSwashbucklerFeature",
+                                              buff.Name,
+                                              buff.Description,
+                                              "52034008859547519fe061a60bd443ee",
+                                              buff.Icon,
+                                              FeatureGroup.None,
+                                              Helpers.CreateAddFact(ability)
+                                              );
+        }
+
+        static void createTerrorOfTheGreatWyrm()
+        {
+            var dazzling_display = library.Get<BlueprintAbility>("5f3126d4120b2b244a95cb2ec23d69fb");
+            var shaken = library.Get<BlueprintBuff>("25ec6cb6ab1845c48a95f9c20b034220");
+            var frightened = library.Get<BlueprintBuff>("f08a7239aa961f34c8301518e71d4cdf");
+            var demoralize = (dazzling_display.GetComponent<AbilityEffectRunAction>().Actions.Actions[0] as Demoralize);
+            var great_wyrm_demoralize = Helpers.Create<TerrorOfTheGreatWyrmDemoralize>(a => { a.Buff = shaken; a.GreaterBuff = frightened; });
+            var fear = library.Get<BlueprintAbility>("d2aeac47450c76347aebbc02e4f463e0");
+            
+            var great_wyrm_demoralize_action = Helpers.CreateAbility("TerrorOfTheGreatWyrmDemoralizeSwashbucklerAbility",
+                                                                     "",
+                                                                     "",
+                                                                     "161e71362f964d758742750374e71232",
+                                                                     null,
+                                                                     AbilityType.Extraordinary,
+                                                                     CommandType.Free,
+                                                                     AbilityRange.Personal,
+                                                                     "",
+                                                                     "",
+                                                                     Helpers.CreateRunActions(great_wyrm_demoralize),
+                                                                     dazzling_display.GetComponent<AbilityTargetsAround>(),
+                                                                     dazzling_display.GetComponent<AbilitySpawnFx>(),
+                                                                     Helpers.Create<CallOfTheWild.NewMechanics.AbilityTargetIsCaster>()
+                                                                     );
+            
+
+            terror_of_the_great_wyrm_buff = CreateBuff("TerrorOfTheGreatWyrmSwashbucklerBuff",
+                                                       "Terror of the Great Wyrm",
+                                                       "At 15th level, the Rostland bravo can use her inevitable victory deed as part of a full attack or dragon’s rage. If a creature demoralized in this way would be shaken for 3 or more rounds, the Rostland bravo can make the target frightened for 1 round before becoming shaken for the appropriate duration.",
+                                                       "f9906d4f50c2479d9a489c6771cc334f",
+                                                       fear.Icon,
+                                                       null,
+                                                       Create<AddInitiatorAttackWithWeaponTrigger>(a => { a.Category = WeaponCategory.DuelingSword; a.OnlyOnFirstAttack = true; a.OnlyOnFullAttack = true; a.Action = CreateActionList(Create<ContextActionCastSpell>(c => c.Spell = great_wyrm_demoralize_action), Create<SpendPanache>(s => { s.resource = Swashbuckler.panache_resource; s.amount = 1; })); })
+                                                       );
+
+            var terror_of_the_great_wyrm_ability = CreateActivatableAbility("TerrorOfTheGreatWyrmSwashbucklerActivatableAbility",
+                                                                            terror_of_the_great_wyrm_buff.Name,
+                                                                            terror_of_the_great_wyrm_buff.Description,
+                                                                            "9f0494e84a3a490ca2d2cc412ac88240",
+                                                                            terror_of_the_great_wyrm_buff.Icon,
+                                                                            terror_of_the_great_wyrm_buff,
+                                                                            AbilityActivationType.Immediately,
+                                                                            CommandType.Free,
+                                                                            null,
+                                                                            CallOfTheWild.Helpers.CreateActivatableResourceLogic(Swashbuckler.panache_resource, ActivatableAbilityResourceLogic.ResourceSpendType.Never)
+                                                                            );
+
+
+            terror_of_the_great_wyrm_deed = CreateFeature("TerrorOfTheGreatWyrmSwashbucklerFeature",
+                                                          terror_of_the_great_wyrm_buff.Name,
+                                                          terror_of_the_great_wyrm_buff.Description,
+                                                          "bb9f3383f6ee40919d1cc434f3c387b8",
+                                                          terror_of_the_great_wyrm_buff.Icon,
+                                                          FeatureGroup.None,
+                                                          Helpers.CreateAddFact(terror_of_the_great_wyrm_ability)
+                                                          );
         }
     }
 }

--- a/Swashbuckler/Swashbuckler.cs
+++ b/Swashbuckler/Swashbuckler.cs
@@ -165,7 +165,8 @@ namespace Derring_Do
             RegisterClass(swashbuckler_class);
 
             InspiredBlade.create();
-            swashbuckler_class.Archetypes = new BlueprintArchetype[] { InspiredBlade.inspired_blade };
+            RostlandBravo.create();
+            swashbuckler_class.Archetypes = new BlueprintArchetype[] { InspiredBlade.inspired_blade, RostlandBravo.rostland_bravo };
 
             SwashbucklerFeats.createFeats();
 

--- a/info.json
+++ b/info.json
@@ -4,8 +4,8 @@
 	"Author": "Eddie",
 	"Version": "1.0.0",
 	"ManagerVersion": "0.13.0",
-	"Requirements": ["CallOfTheWild"],
-	"LoadAfter": ["CallOfTheWild"],
+	"Requirements": ["CallOfTheWild", "ProperFlanking2"],
+	"LoadAfter": ["CallOfTheWild", "ProperFlanking2"],
 	"AssemblyName": "Derring-Do.dll",
 	"EntryMethod": "Derring_Do.Main.Load"
 }


### PR DESCRIPTION
Adds in the [Rostland Bravo](https://aonprd.com/ArchetypeDisplay.aspx?FixedName=Swashbuckler%20Rostland%20Bravo) archetype:
Some potential issues:
- Terror of the Great Wyrm deed may not account for some Intimidate modifiers
- Dragon's Rage deed treats the extra attack as the first for providing extra panache on kill (may change to second)
- Inevitable Victory should downgrade Dazzling Display to be not recommended for feat choices on the recommendation pass
- Sweeping Wind feint has no animation due to being a swift action

ADDED DEPENDANCY:
- Project now depends on ProperFlanking2 due to Feint mechanics